### PR TITLE
use `minicbor::bytes`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -16,6 +16,7 @@ dependencies = [
  "rand",
  "serde",
  "serde_bare",
+ "serde_bytes",
 ]
 
 [[package]]
@@ -133,6 +134,15 @@ name = "serde_bare"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51c55386eed0f1ae957b091dc2ca8122f287b60c79c774cbe3d5f2b69fded660"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "serde_bytes"
+version = "0.11.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16ae07dd2f88a366f15bd0632ba725227018c69a1c8550a927324f8eb8368bb9"
 dependencies = [
  "serde",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,4 +8,4 @@ minicbor   = { version = "0.13.2", features = ["std", "derive"] }
 rand       = "0.8"
 serde      = { version = "1.0", features = ["derive"] }
 serde_bare = "0.5.0"
-
+serde_bytes = "0.11"

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,32 +1,44 @@
-use minicbor::{Decode, Encode};
+use minicbor::{bytes::ByteVec, Decode, Encode};
 use rand::distributions::{Alphanumeric, Standard};
 use rand::{rngs::ThreadRng, Rng, RngCore};
 use serde::{Deserialize, Serialize};
 use std::iter;
 
-#[derive(Debug, Clone, Encode, Decode, Serialize, Deserialize)]
-struct TransportMessage {
+#[derive(Debug, Clone, Encode, Decode)]
+struct TransportMessageCbor {
     #[n(0)]
     version: u8,
     #[n(1)]
-    onward_route: Vec<Vec<u8>>,
+    onward_route: Vec<minicbor::bytes::ByteVec>,
     #[n(2)]
-    return_route: Vec<Vec<u8>>,
+    return_route: Vec<minicbor::bytes::ByteVec>,
     #[n(3)]
+    #[cbor(with = "minicbor::bytes")]
+    payload: Vec<u8>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct TransportMessageSerde {
+    version: u8,
+    onward_route: Vec<serde_bytes::ByteBuf>,
+    return_route: Vec<serde_bytes::ByteBuf>,
+    #[serde(with = "serde_bytes")]
     payload: Vec<u8>,
 }
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let inner_bare = serde_bare::to_vec(&TransportMessage {
+    let inner_bare = serde_bare::to_vec(&TransportMessageSerde {
         version: 0,
-        onward_route: vec!["0#app".as_bytes().to_vec()],
+        // `serde_bytes::ByteBuf` doesn't implement `From`, and just has a
+        // constructor function named `from` :/
+        onward_route: vec![serde_bytes::ByteBuf::from("0#app".as_bytes())],
         return_route: vec![],
         payload: serde_bare::to_vec(&String::from("Hello ockam"))?,
     })?;
 
-    let inner_cbor = minicbor::to_vec(&TransportMessage {
+    let inner_cbor = minicbor::to_vec(&TransportMessageCbor {
         version: 0,
-        onward_route: vec!["0#app".as_bytes().to_vec()],
+        onward_route: vec!["0#app".as_bytes().to_vec().into()],
         return_route: vec![],
         payload: minicbor::to_vec(&String::from("Hello ockam"))?,
     })?;
@@ -34,21 +46,21 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let len_inner_bare = inner_bare.len();
     let len_inner_cbor = inner_cbor.len();
 
-    let outer_bare = serde_bare::to_vec(&TransportMessage {
+    let outer_bare = serde_bare::to_vec(&TransportMessageSerde {
         version: 0,
         onward_route: vec![
-            "1#hub.ockam.network".as_bytes().to_vec(),
-            "0#my-pipe-friend".as_bytes().to_vec(),
+            serde_bytes::ByteBuf::from("1#hub.ockam.network".as_bytes().to_vec()),
+            serde_bytes::ByteBuf::from("0#my-pipe-friend".as_bytes().to_vec()),
         ],
         return_route: vec![],
         payload: inner_bare,
     })?;
 
-    let outer_cbor = minicbor::to_vec(&TransportMessage {
+    let outer_cbor = minicbor::to_vec(&TransportMessageCbor {
         version: 0,
         onward_route: vec![
-            "1#hub.ockam.network".as_bytes().to_vec(),
-            "0#my-pipe-friend".as_bytes().to_vec(),
+            "1#hub.ockam.network".as_bytes().to_vec().into(),
+            "0#my-pipe-friend".as_bytes().to_vec().into(),
         ],
         return_route: vec![],
         payload: inner_cbor,
@@ -57,21 +69,21 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let len_outer_bare = outer_bare.len();
     let len_outer_cbor = outer_cbor.len();
 
-    let outest_bare = serde_bare::to_vec(&TransportMessage {
+    let outest_bare = serde_bare::to_vec(&TransportMessageSerde {
         version: 0,
         onward_route: vec![
-            "1#hub.ockam.network".as_bytes().to_vec(),
-            "0#my-pipe-friend".as_bytes().to_vec(),
+            serde_bytes::ByteBuf::from("1#hub.ockam.network".as_bytes().to_vec()),
+            serde_bytes::ByteBuf::from("0#my-pipe-friend".as_bytes().to_vec()),
         ],
         return_route: vec![],
         payload: outer_bare,
     })?;
 
-    let outest_cbor = minicbor::to_vec(&TransportMessage {
+    let outest_cbor = minicbor::to_vec(&TransportMessageCbor {
         version: 0,
         onward_route: vec![
-            "1#hub.ockam.network".as_bytes().to_vec(),
-            "0#my-pipe-friend".as_bytes().to_vec(),
+            "1#hub.ockam.network".as_bytes().to_vec().into(),
+            "0#my-pipe-friend".as_bytes().to_vec().into(),
         ],
         return_route: vec![],
         payload: outer_cbor,


### PR DESCRIPTION
With this the numbers are:

```
>>> Inner message
BARE =   22 bytes (100.00%)
CBOR =   23 bytes (104.55%)

>>> Outer message
BARE =   63 bytes (100.00%)
CBOR =   65 bytes (103.17%)

>>> Outest message
BARE =  104 bytes (100.00%)
CBOR =  108 bytes (103.85%)
```

For comparison, the numbers for the version on `main` are here:
```
>>> Inner message
BARE =   22 bytes (100.00%)
CBOR =   40 bytes (181.82%)

>>> Outer message
BARE =   63 bytes (100.00%)
CBOR =  157 bytes (249.21%)

>>> Outest message
BARE =  104 bytes (100.00%)
CBOR =  390 bytes (375.00%)
```

So it removes almost all the overhead.

This code also switches the serde case to use [`serde_bytes`](https://docs.rs/serde_bytes/latest/serde_bytes). For `BARE` it will make no difference in size (because fixed size integers are represented directly). If other formats are checked using the same code for some reason, this may help them though, and ideally it would be used in `ockam` if we stick with BARE, since it avoids the cost of encoding each byte individually, which LLVM often won't optimize without some real compiler heroics (and LLVM almost certainly never will do those if we use `-Copt-level=[sz]` (which we should expect our embedded users to use), because the inlining required would be... significant).

I did that just because I was curious if my assumption was correct that it wouldn't help out the BARE case (and it was).